### PR TITLE
Fix: normalize 'onetime' key type (replace 'one_time' occurrences)

### DIFF
--- a/app/api/views.py
+++ b/app/api/views.py
@@ -120,7 +120,7 @@ def get_transaction(txid):
 @api.post("/dump")
 def dump():
     rows = query_db(
-        'select * from keys where symbol = ? or type != "one_time"', (g.symbol,)
+        'select * from keys where symbol = ? or type != "onetime"', (g.symbol,)
     )
     keys = []
     for row in rows:

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -355,7 +355,7 @@ def transfer_trc20_from(onetime_acc, symbol):
                 return
 
             # Check available bandwidth before transfer trc20 tokens
-            # from one_time to fee_deposit account
+            # from onetime to fee_deposit account
             if not has_free_bw(
                 onetime_publ_key, config.BANDWIDTH_PER_TRC20_TRANSFER_CALL
             ):


### PR DESCRIPTION
## Summary
Normalize key-type usage from `one_time` to the canonical `onetime` value used in schema.

## Changes
- `app/api/views.py`: change SQL filter from `type != "one_time"` to `type != "onetime"`.
- `app/tasks.py`: update comment text to use `onetime` naming for consistency.

## Why
The codebase defines `onetime` in `app/schemas.py`, so using `one_time` could lead to inconsistent key matching and incorrect filtering behavior.

## Scope / Risk
Small, low-risk normalization fix touching only 2 files.