### PR TITLE
fix(connection_manager): add missing sleep in refresh_best_server loop

### DIFF
--- a/app/connection_manager.py
+++ b/app/connection_manager.py
@@ -172,6 +172,7 @@ class ConnectionManager:
 
             while True:
                 self.refresh_best_server()
+                time.sleep(config.MULTISERVER_REFRESH_BEST_SERVER_PERIOD)
         except Exception as e:
             logger.warning(f"Exception in best server refresh loop: {e}")
         finally:


### PR DESCRIPTION
refresh_best_server_thread_handler had time.sleep() in the finally: block instead of inside the while True: loop. As a result the thread spun on refresh_best_server() with no delay between iterations, pinning one gunicorn worker at ~98% CPU and leaking file descriptors on the SQLite-backed connection cache (observed: 288+ FDs on a single DB).

Move the sleep into the loop body so the configured MULTISERVER_REFRESH_BEST_SERVER_PERIOD is honored between refreshes.

Observed on vsyshost/tron-shkeeper:1.1.12 in production; CPU drops back to single-digit % immediately after the patch.