### PR TITLE
Fix: normalize 'onetime' key type (replace 'one_time' occurrences)

### DIFF
--- a/app/api/views.py
+++ b/app/api/views.py
@@ -120,7 +120,7 @@ def get_transaction(txid):
 @api.post("/dump")
 def dump():
     rows = query_db(
-        'select * from keys where symbol = ? or type != "one_time"', (g.symbol,)
+        'select * from keys where symbol = ? or type != "onetime"', (g.symbol,)
     )
     keys = []
     for row in rows:

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -355,7 +355,7 @@ def transfer_trc20_from(onetime_acc, symbol):
                 return
 
             # Check available bandwidth before transfer trc20 tokens
-            # from one_time to fee_deposit account
+            # from onetime to fee_deposit account
             if not has_free_bw(
                 onetime_publ_key, config.BANDWIDTH_PER_TRC20_TRANSFER_CALL
             ):


### PR DESCRIPTION
Supersedes #24 — moved off the fork `master` branch onto a dedicated branch and rebased onto the latest `master`.

## The bug — `/dump` filters on a key-type string that never exists

https://github.com/vsys-host/tron-shkeeper/blob/48f70e251b15b7d1c3fef7b1cf17e966fc28ad54/app/api/views.py#L120-L124

The predicate `type != "one_time"` can never match a real row, because key types are stored as `"onetime"` (no underscore):

https://github.com/vsys-host/tron-shkeeper/blob/48f70e251b15b7d1c3fef7b1cf17e966fc28ad54/app/schemas.py#L10-L13

Rows are inserted with `'onetime'`:

https://github.com/vsys-host/tron-shkeeper/blob/48f70e251b15b7d1c3fef7b1cf17e966fc28ad54/app/api/views.py#L27

…and every other query in the codebase matches on `"onetime"`, e.g.:

https://github.com/vsys-host/tron-shkeeper/blob/48f70e251b15b7d1c3fef7b1cf17e966fc28ad54/app/tasks.py#L497

https://github.com/vsys-host/tron-shkeeper/blob/48f70e251b15b7d1c3fef7b1cf17e966fc28ad54/app/tasks.py#L575

https://github.com/vsys-host/tron-shkeeper/blob/48f70e251b15b7d1c3fef7b1cf17e966fc28ad54/app/utils.py#L40

`views.py:123` is the only site using `"one_time"`.

## Impact

No row has `type == "one_time"`, so `type != "one_time"` is always true and
`WHERE symbol = ? OR <always-true>` collapses to always-true. `/dump` then
returns **every** key in the table (including all onetime address private keys)
instead of the intended subset (this symbol's keys plus non-onetime accounts).

## Fix

- `app/api/views.py`: `type != "one_time"` → `type != "onetime"`
- `app/tasks.py`: fix a stale `one_time` comment to `onetime`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
