### PR TITLE
Lower TRON activation transfer amount

### DIFF
--- a/app/tasks.py
+++ b/app/tasks.py
@@ -258,17 +258,20 @@ def transfer_trc20_from(onetime_acc, symbol):
                     )
                     return
 
-            logger.info(f"Activating {onetime_publ_key} by sending 0.1 TRX")
+            activation_amount = Decimal("0.00001")
+            logger.info(
+                f"Activating {onetime_publ_key} by sending {activation_amount} TRX"
+            )
             tx_trx = tron_client.trx.transfer(
                 main_publ_key,
                 onetime_publ_key,
-                int(0.1 * 1_000_000),
+                int(activation_amount * 1_000_000),
             )
             tx_trx._raw_data["expiration"] = current_timestamp() + 60_000
             tx_trx = tx_trx.build()
             tx_trx = tx_trx.sign(main_priv_key)
             tx_trx_res = tx_trx.broadcast().wait()
-            logger.info(f"0.1 TRX sent. Details: {tx_trx_res}")
+            logger.info(f"{activation_amount} TRX sent. Details: {tx_trx_res}")
             onetime_address_resources = tron_client.get_account_resource(
                 onetime_publ_key
             )


### PR DESCRIPTION
## Summary

Lower the TRON one-time account activation transfer from `0.1 TRX` to `0.00001 TRX` in the TRC20 sweep flow.

## Why

The previous hard-coded activation amount can overfund generated deposit accounts. This keeps activation minimal while preserving the existing transfer and resource check flow.

## Changes

- Introduce an `activation_amount = Decimal("0.00001")` value near the activation transfer.
- Use that value when converting to sun for `tron_client.trx.transfer`.
- Update activation log messages so they report the actual amount.

## Validation

- `python3 -m py_compile app/tasks.py`
